### PR TITLE
feat: allow custom max_ws_frame_size parameter

### DIFF
--- a/cdp_use/client.py
+++ b/cdp_use/client.py
@@ -227,9 +227,15 @@ ws_logger.addFilter(WebSocketLogFilter())
 
 
 class CDPClient:
-    def __init__(self, url: str, additional_headers: Optional[Dict[str, str]] = None):
+    def __init__(
+        self,
+        url: str,
+        additional_headers: Optional[Dict[str, str]] = None,
+        max_ws_frame_size: int = 100 * 1024 * 1024,  # Default 100MB
+    ):
         self.url = url
         self.additional_headers = additional_headers
+        self.max_ws_frame_size = max_ws_frame_size
         self.ws: Optional[websockets.ClientConnection] = None
         self.msg_id: int = 0
         self.pending_requests: Dict[int, asyncio.Future] = {}
@@ -265,9 +271,11 @@ class CDPClient:
         if self.ws is not None:
             raise RuntimeError("Client is already started")
 
-        logger.info(f"Connecting to {self.url}")
+        logger.info(
+            f"Connecting to {self.url} (max frame size: {self.max_ws_frame_size / 1024 / 1024:.0f}MB)"
+        )
         connect_kwargs = {
-            "max_size": 100 * 1024 * 1024,  # 100MB limit instead of default 1MB
+            "max_size": self.max_ws_frame_size,
         }
         if self.additional_headers:
             connect_kwargs["additional_headers"] = self.additional_headers


### PR DESCRIPTION
Enhance CDPClient initialization with max_ws_frame_size parameter and update connection logging to include frame size

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a max_ws_frame_size option to CDPClient so callers can set the WebSocket frame size limit. Default stays 100MB, and the connect log now shows the configured size.

- **New Features**
  - New max_ws_frame_size parameter in CDPClient (default 100MB).
  - start() uses this value for websockets max_size.
  - Connection log prints the frame size in MB.

<sup>Written for commit eb30748f63a2a3b8ddb16f16f9f130ced2939145. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

