### PR TITLE
fix: sync registry_generator.py with async event handler changes

### DIFF
--- a/cdp_use/generator/registry_generator.py
+++ b/cdp_use/generator/registry_generator.py
@@ -75,7 +75,6 @@ class RegistryGenerator:
         content += '        """\n'
         content += "        if method in self._handlers:\n"
         content += "            try:\n"
-        content += "                import asyncio\n"
         content += "                import inspect\n"
         content += "                handler = self._handlers[method]\n\n"
         content += "                # Check if handler is async\n"


### PR DESCRIPTION
- This fixes the generator to match the changes made in commit 4fed163, which added async event handler support to cdp/registry.py but didn't update the generator. Without this fix, regenerating the code would revert the async handler changes and cause runtime errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates registry_generator.py to generate an async handle_event that matches the async handler support in cdp/registry.py, preventing regenerated code from breaking at runtime.

- **Bug Fixes**
  - Make handle_event async and await coroutine handlers; call sync handlers directly.
  - Detect async handlers with inspect.iscoroutinefunction to preserve correct behavior during code generation.

<sup>Written for commit 9a1c62d2b0b8838c55276d219d849b66cad01792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

