### PR TITLE
Add Browser Use Box CDP note

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ async def main():
 asyncio.run(main())
 ```
 
+Need a ready long-lived Browser Use Cloud browser to connect to from your own VPS? See [Browser Use Box](https://browser-use.com/bux) and the [15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ### Type Safety in Action
 
 ```python


### PR DESCRIPTION
## Summary
- add Browser Use Box as a ready long-lived Browser Use Cloud browser option for CDP examples
- include the 15-second Browser Use Box TikTok demo link

## Validation
- README-only change; verified Browser Use Box and TikTok demo links are present locally

Browser Use Box: https://browser-use.com/bux
TikTok demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a short README note linking to Browser Use Box, a ready, long‑lived Browser Use Cloud browser for CDP examples, plus a 15‑second demo. This gives users a quick way to connect from their VPS without extra setup.

<sup>Written for commit 0afc904aac814b49b8d5455a56a56c5f33bd930f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

