### PR TITLE
fix: suppress CDP error -32000 to prevent session corruption

### DIFF
--- a/cdp_use/client.py
+++ b/cdp_use/client.py
@@ -238,7 +238,7 @@ class CDPClient:
         self.max_ws_frame_size = max_ws_frame_size
         self.ws: Optional[websockets.ClientConnection] = None
         self.msg_id: int = 0
-        self.pending_requests: Dict[int, asyncio.Future] = {}
+        self.pending_requests: Dict[int, tuple[asyncio.Future, str]] = {}
         self._message_handler_task = None
 
         # Initialize the type-safe CDP library
@@ -311,23 +311,30 @@ class CDPClient:
 
                 # Handle response messages (with id)
                 if "id" in data and data["id"] in self.pending_requests:
-                    future = self.pending_requests.pop(data["id"])
+                    future, request_method = self.pending_requests.pop(data["id"])
                     # Check if future is already done to avoid InvalidStateError
                     if not future.done():
                         if "error" in data:
                             error = data["error"]
-                            # Suppress CDP error -32000 "Browser window not found".
-                            # This error occurs during race conditions when getWindowForTarget
-                            # is called for a target that doesn't yet have an associated window
-                            # (e.g., during file uploads, page transitions, or new tab creation).
-                            # The target exists in CDP but has no window binding yet, so
-                            # Browser.getWindowForTarget returns -32000. Returning a default
-                            # result prevents the event handler from crashing and corrupting
-                            # the session.
-                            if isinstance(error, dict) and error.get("code") == -32000:
+                            # Suppress CDP error -32000 "Browser window not found"
+                            # only for Browser.getWindowForTarget.
+                            # This error occurs during race conditions when
+                            # getWindowForTarget is called for a target that doesn't
+                            # yet have an associated window (e.g., during file uploads,
+                            # page transitions, or new tab creation). The target exists
+                            # in CDP but has no window binding yet, so
+                            # Browser.getWindowForTarget returns -32000. Returning a
+                            # default result prevents the event handler from crashing and
+                            # corrupting the session.
+                            if (
+                                isinstance(error, dict)
+                                and error.get("code") == -32000
+                                and request_method == "Browser.getWindowForTarget"
+                            ):
                                 logger.info(
-                                    f"CDP error {error.get('code')} suppressed for request "
-                                    f"{data['id']}: {error.get('message', 'unknown')} - "
+                                    f"CDP error {error.get('code')} suppressed for "
+                                    f"Browser.getWindowForTarget request {data['id']}: "
+                                    f"{error.get('message', 'unknown')} - "
                                     f"returning default window result"
                                 )
                                 future.set_result({
@@ -372,14 +379,14 @@ class CDPClient:
         except websockets.exceptions.ConnectionClosed as e:
             logger.debug(f"WebSocket connection closed: {e}")
             # Connection closed, resolve all pending futures with an exception
-            for future in self.pending_requests.values():
+            for future, _ in self.pending_requests.values():
                 if not future.done():
                     future.set_exception(ConnectionError("WebSocket connection closed"))
             self.pending_requests.clear()
         except Exception as e:
             logger.error(f"Error in message handler: {e}")
             # Handle other exceptions
-            for future in self.pending_requests.values():
+            for future, _ in self.pending_requests.values():
                 if not future.done():
                     future.set_exception(e)
             self.pending_requests.clear()
@@ -405,9 +412,9 @@ class CDPClient:
         if session_id:
             msg["sessionId"] = session_id
 
-        # Create a future for this request
+        # Create a future for this request, storing method for error handling
         future = asyncio.Future()
-        self.pending_requests[self.msg_id] = future
+        self.pending_requests[self.msg_id] = (future, method)
 
         await self.ws.send(json.dumps(msg))
 

--- a/cdp_use/client.py
+++ b/cdp_use/client.py
@@ -315,10 +315,36 @@ class CDPClient:
                     # Check if future is already done to avoid InvalidStateError
                     if not future.done():
                         if "error" in data:
-                            logger.debug(
-                                f"CDP Error for request {data['id']}: {data['error']}"
-                            )
-                            future.set_exception(RuntimeError(data["error"]))
+                            error = data["error"]
+                            # Suppress CDP error -32000 "Browser window not found".
+                            # This error occurs during race conditions when getWindowForTarget
+                            # is called for a target that doesn't yet have an associated window
+                            # (e.g., during file uploads, page transitions, or new tab creation).
+                            # The target exists in CDP but has no window binding yet, so
+                            # Browser.getWindowForTarget returns -32000. Returning a default
+                            # result prevents the event handler from crashing and corrupting
+                            # the session.
+                            if isinstance(error, dict) and error.get("code") == -32000:
+                                logger.info(
+                                    f"CDP error {error.get('code')} suppressed for request "
+                                    f"{data['id']}: {error.get('message', 'unknown')} - "
+                                    f"returning default window result"
+                                )
+                                future.set_result({
+                                    "windowId": 0,
+                                    "bounds": {
+                                        "left": 0,
+                                        "top": 0,
+                                        "width": 1920,
+                                        "height": 1080,
+                                        "windowState": "normal",
+                                    },
+                                })
+                            else:
+                                logger.debug(
+                                    f"CDP Error for request {data['id']}: {error}"
+                                )
+                                future.set_exception(RuntimeError(error))
                         else:
                             future.set_result(data["result"])
                     else:


### PR DESCRIPTION
## Problem

When using browser automation tools that depend on cdp-use, file uploads and page transitions consistently cause browser sessions to become unusable with the error:

```
RuntimeError: {"code": -32000, "message": "Browser window not found"}
```

This makes all subsequent commands (`state`, `wait stable`, `screenshot`, etc.) fail, rendering the browser session permanently broken.

## Root Cause

The error occurs during a race condition in the CDP event handler:

1. `_on_target_info_changed` fires when a new target is discovered (e.g., file upload or page navigation creates a new page context)
2. `_trigger_page_target_discovered` calls `Browser.getWindowForTarget` for the new target
3. The target exists in CDP but doesn't yet have an associated window binding
4. CDP returns error `-32000` ("Browser window not found")
5. The `RuntimeError` is raised and propagates through the event handler
6. The unhandled exception crashes the event handler and corrupts the session
7. All subsequent CDP calls fail because the session state is inconsistent

## Fix

In `CDPClient._handle_messages()`, when a CDP response contains error `-32000`, return a default window result instead of raising `RuntimeError`. This allows the session to continue normally — the target will get its window binding shortly after.

Other CDP errors are still raised as `RuntimeError` as before.

## Testing

Verified with browser-act:
- ✅ Open browser session
- ✅ Navigate to pages
- ✅ File uploads (previously crashed the session)
- ✅ Click buttons and interact with elements
- ✅ `state` command works after interactions
- ✅ `wait stable` command works after interactions
- ✅ Complete automation flow works end-to-end

## Changes

- `cdp_use/client.py`: Added error suppression for CDP error code `-32000` in `_handle_messages()`, returning a default window result `{"windowId": 0, "bounds": {"left": 0, "top": 0, "width": 1920, "height": 1080, "windowState": "normal"}}` instead of raising `RuntimeError`